### PR TITLE
Add :resets option to router url map configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,14 @@ class AppDelegate
 
     # :modal means we push it modally.
     @router.map("login", LoginController, modal: true)
+
     # :shared means it will only keep one instance of this VC in the hierarchy;
     # if we push it again later, it will pop any covering VCs.
     @router.map("menu", MenuController, shared: true)
     @router.map("profile/:id", ProfileController)
-    @router.map("messages", MessagesController)
+
+    # :resets will reset the navigation stack with the target view controller
+    @router.map("messages", MessagesController, resets: true)
     @router.map("message/:id", MessageThreadController)
 
     # can also route arbitrary blocks of code

--- a/lib/routable/router.rb
+++ b/lib/routable/router.rb
@@ -47,6 +47,8 @@ module Routable
     #     - We present the VC modally (router is not shared between the new nav VC)
     #   :shared => true/false
     #     - If URL is called again, we pop to that VC if it's in memory.
+    #   :resets => true/false
+    #     - Resets the navigation stack with the target view controller
     #   :transition => [:cover, :flip, :dissolve, :curl]
     #     - A symbol to represented transition style used. Mapped to UIModalTransitionStyle.
     #   :presentation => [:full_screen, :page_sheet, :form_sheet, :current]
@@ -108,7 +110,10 @@ module Routable
 
         self.navigation_controller.dismissModalViewControllerAnimated(dismiss_animated)
       end
-      if controller_options[:modal]
+
+      if controller_options[:resets]
+        navigation_controller.setViewControllers([controller], animated: animated)
+      elsif controller_options[:modal]
         if controller.class == UINavigationController
           self.navigation_controller.presentModalViewController(controller, animated: animated)
         else

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -121,4 +121,17 @@ describe "the url router" do
     @router.open("logout/123")
     @called.should == "123"
   end
+
+  describe 'reset option' do
+    it 'resets the navigation controller stack with the target controller' do
+      @router.navigation_controller = @nav_controller
+      @router.map('start', NoParamsController)
+      @router.map('reset', NoParamsController, resets: true)
+
+      @router.open('start')
+      @router.open('reset')
+
+      @router.navigation_controller.viewControllers.count.should == 1
+    end
+  end
 end


### PR DESCRIPTION
Useful for navigating to view controllers that should replace the entire stack.

``` ruby
router.map('login', LoginController, resets: true, shared: true)
```
