### PR TITLE
Add configuration block support to open method

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,16 @@ class AppDelegate
   end
 end
 ```
+
+## Configuration of View Controllers
+
+If you need to configure a view controller before the router navigates to it, use a block:
+
+``` ruby
+# Configure and push an ImageEditorController
+BW::Device.camera.any.picture(media_types: [:movie, :image]) do |result|
+  router.open('editor') do |controller|
+    controller.image = result[:original_image]
+  end
+end
+```

--- a/lib/routable/router.rb
+++ b/lib/routable/router.rb
@@ -83,7 +83,7 @@ module Routable
     # EX
     # router.open("users/3")
     # => router.navigation_controller pushes a UsersController
-    def open(url, animated = true)
+    def open(url, animated = true, &block)
       controller_options = options_for_url(url)
 
       if controller_options[:callback]
@@ -99,6 +99,13 @@ module Routable
       end
 
       controller = controller_for_url(url)
+
+      # Allow configuration of the view controller after
+      # initialization but before navigating to the view controller
+      if block_given?
+        block.call(controller)
+      end
+
       if self.navigation_controller.modalViewController
         dismiss_animated = animated
 

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -14,6 +14,16 @@ end
 class LoginController < UIViewController
 end
 
+class ConfigurableController < UIViewController
+  attr_accessor :configured
+
+  def init
+    super.tap do |controller|
+      controller.configured = false
+    end
+  end
+end
+
 describe "the url router" do
   before do
     @router = Routable::Router.new
@@ -21,6 +31,21 @@ describe "the url router" do
     @nav_controller = UINavigationController.alloc.init
     @nav_controller.setViewControllers([], animated: false)
     @nav_controller.viewControllers.count.should == 0
+  end
+
+  describe '#open' do
+    it 'accepts a configuration block' do
+      url = 'configured'
+      @router.navigation_controller = @nav_controller
+      @router.map(url, ConfigurableController, shared: true)
+
+      @router.open(url) do |controller|
+        controller.configured = true
+      end
+
+      controller = @router.controller_for_url(url)
+      controller.configured.should.be.true
+    end
   end
 
   def make_test_controller_route


### PR DESCRIPTION
Supports configuration of the view controller after initialization but before navigating to the view controller:

``` ruby
# Configure and push an ImageEditorController
BW::Device.camera.any.picture(media_types: [:movie, :image]) do |result|
  router.open('editor') do |controller|
    controller.image = result[:original_image]
  end
end
```
