### PR TITLE
Handle unmapped routes

### DIFF
--- a/lib/routable/router.rb
+++ b/lib/routable/router.rb
@@ -1,4 +1,7 @@
 module Routable
+
+  class RouteNotFound < Exception; end
+
   class Router
     TRANSITION_STYLES = {
       :cover => UIModalTransitionStyleCoverVertical,
@@ -84,6 +87,10 @@ module Routable
     # router.open("users/3")
     # => router.navigation_controller pushes a UsersController
     def open(url, animated = true, &block)
+      if self.routes.exclude? url
+        raise RouteNotFound, "No route found for URL '#{url}'"
+      end
+
       controller_options = options_for_url(url)
 
       if controller_options[:callback]
@@ -202,10 +209,6 @@ module Routable
         open_params = format_params
       }
 
-      if open_options == nil
-        raise "No route found for url #{url}"
-      end
-
       @url_options_cache[url] = open_options.merge(open_params: open_params)
     end
 
@@ -249,7 +252,7 @@ module Routable
 
       presentation = open_options[:presentation]
       if presentation
-        controller.modalPresentationStyle = PRESENTATION_STYLES[presentation] 
+        controller.modalPresentationStyle = PRESENTATION_STYLES[presentation]
       end
 
       controller


### PR DESCRIPTION
At the moment, every supported URL has to be explicitly mapped, otherwise the
app crashes and raises a `RuntimeError`. Introducing our own exception class lets
us rescue that specific error in our app so we can handle it accordingly.